### PR TITLE
增加默认语言设置

### DIFF
--- a/library/src/main/java/com/hjq/language/LanguagesConfig.java
+++ b/library/src/main/java/com/hjq/language/LanguagesConfig.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
 
-import androidx.annotation.Nullable;
-
 import java.util.List;
 import java.util.Locale;
 
@@ -23,11 +21,9 @@ final class LanguagesConfig {
     private static String sSharedPreferencesName = "language_setting";
 
     private static volatile Locale sCurrentLanguage;
-    
-    @Nullable
+
     private static List<Locale> sSupportedLanguages;
 
-    @Nullable
     private static Locale sDefaultLocale;
 
     static void setSharedPreferencesName(String name) {

--- a/library/src/main/java/com/hjq/language/MultiLanguages.java
+++ b/library/src/main/java/com/hjq/language/MultiLanguages.java
@@ -115,15 +115,15 @@ public final class MultiLanguages {
      */
     public static boolean clearAppLanguage(Context context) {
         LanguagesConfig.clearLanguage(context);
-        if (LanguagesUtils.getLocale(context).equals(getSystemLanguage())) {
+        if (LanguagesUtils.getLocale(context).equals(LanguagesConfig.getDefaultLanguage())) {
             return false;
         }
 
-        LanguagesUtils.updateLanguages(context.getResources(), getSystemLanguage());
+        LanguagesUtils.updateLanguages(context.getResources(), LanguagesConfig.getDefaultLanguage());
         LanguagesUtils.setDefaultLocale(context);
         if (context != sApplication) {
             // 更新 Application 的语种
-            LanguagesUtils.updateLanguages(sApplication.getResources(), getSystemLanguage());
+            LanguagesUtils.updateLanguages(sApplication.getResources(), LanguagesConfig.getDefaultLanguage());
         }
         return true;
     }

--- a/library/src/main/java/com/hjq/language/MultiLanguages.java
+++ b/library/src/main/java/com/hjq/language/MultiLanguages.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.res.Resources;
 
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -188,5 +189,12 @@ public final class MultiLanguages {
      */
     static Application getApplication() {
         return sApplication;
+    }
+    
+     /**
+     * 设置App不支持系统语言时的语言
+     */
+    public static void setDefaultLanguageIfAppNotSupport(List<Locale> supportedLocale, Locale defaultLocale) {
+        LanguagesConfig.setDefaultLanguageIfNotSupport(supportedLocale, defaultLocale);
     }
 }


### PR DESCRIPTION
假设app不支持日语，而系统语言恰好是日语。轮子哥的逻辑会直接使用系统语言日语，从而导致应用内出现部分日语（第三方或系统string）。所以，我增加了一个默认设置，在不设置的情况下，走轮子哥原来的逻辑。设置后，app不支持该语言时，使用设置的语言。